### PR TITLE
ignore err while searching in parallel

### DIFF
--- a/search/search.go
+++ b/search/search.go
@@ -40,12 +40,12 @@ func Search(
 	for generated := range in {
 		res, err := eval.Evaluate(familyName, generated.GivenName, strokesFunc)
 		if err != nil {
-			return err
+			continue
 		}
 
 		s, err := strokes.Sum(generated.GivenName, strokesFunc)
 		if err != nil {
-			return err
+			continue
 		}
 
 		target := filter.Target{


### PR DESCRIPTION
ある名前が画数が多すぎるなどするとevalでerrが出てsearchが途中で終わるので無視するようにしました